### PR TITLE
Improve macos support

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,7 @@ use std::env;
 
 fn main() {
     let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    if cfg!(unix) {
+    if cfg!(unix) && !cfg!(macos) {
         // Set soname for platforms other than Windows
         const VERSION_MAJOR: &'static str = env!("CARGO_PKG_VERSION_MAJOR");
         println!("cargo:rustc-cdylib-link-arg=-Wl,-soname,libetebase.so.{}", VERSION_MAJOR);


### PR DESCRIPTION
This PR improves macOS support by not changing the SO-Name on macOS, as macOS dylibs are not versioned.