### PR TITLE
c_tests/Makefile: Make MODE configurable and default to release

### DIFF
--- a/c_tests/Makefile
+++ b/c_tests/Makefile
@@ -1,5 +1,7 @@
 TARGET = tests
-LIBS = -L. -l:../target/debug/libetebase.so
+# Set MODE to debug to build in debug mode
+MODE ?= release
+LIBS = -L. -l:../target/$(MODE)/libetebase.so
 CC = gcc
 CFLAGS = -g -Wall -I ../target
 


### PR DESCRIPTION
Accordingly, the main Makefile's "check" target will pass its MODE environment variable on to c_tests/Makefile.

Fixes #17

---

Not sure if defaulting to release is actually what you want? However it at least fixes the issue that when the main Makefile was run with MODE=release `make check` will run successfully.